### PR TITLE
fixed lookup defect

### DIFF
--- a/lib/chef/provisioning/aws_driver/aws_resource.rb
+++ b/lib/chef/provisioning/aws_driver/aws_resource.rb
@@ -100,8 +100,9 @@ module AWSDriver
             options[name] = [options[name]].flatten.map { |value| aws_option_handlers[handler_name].get_aws_object_id(value, **handler_options) }
           end
         else
-          if aws_option_handlers[name]
-            options[name] = aws_option_handlers[name].get_aws_object_id(value, **handler_options)
+          handler_name = name.to_sym
+          if aws_option_handlers[handler_name]
+            options[handler_name] = aws_option_handlers[handler_name].get_aws_object_id(value, **handler_options)
           end
         end
       end


### PR DESCRIPTION
`name` was getting converted into a `string` here when the resource property was nested in a machine_batch.  This pr fixes that issue by always converting name into an appropriately named symbol.

In particular, this was flairing up for me where `aws_option_handlers['subnet']` was not defined, but `aws_options_handlers[:subnet]` was defined.  If you look at the other section of code above this (L98) you can also see that they are converting the name into a symbol, so this seems like a logical fix here.